### PR TITLE
Refactor export as service

### DIFF
--- a/DependencyInjection/SuluImportExportExtension.php
+++ b/DependencyInjection/SuluImportExportExtension.php
@@ -35,5 +35,6 @@ class SuluImportExportExtension extends Extension
 
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('command.xml');
+        $loader->load('services.xml');
     }
 }

--- a/Resources/config/command.xml
+++ b/Resources/config/command.xml
@@ -4,21 +4,11 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <service id="sulu.command.import" class="TheCadien\Bundle\SuluImportExportBundle\Command\ImportCommand">
-            <argument key="$databaseHost">%env(DATABASE_HOST)%</argument>
-            <argument key="$databaseUser">%env(DATABASE_USER)%</argument>
-            <argument key="$databaseName">%env(DATABASE_NAME)%</argument>
-            <argument key="$databasePassword">%env(DATABASE_PASSWORD)%</argument>
-            <argument key="$importDirectory">%kernel.project_dir%</argument>
-            <argument key="$uploadsDirectory">%env(MEDIA_PATH)%</argument>
+            <argument key="$importService" type="service" id="sulu.service.import"/>
             <tag name="console.command"/>
         </service>
         <service id="sulu.command.export" class="TheCadien\Bundle\SuluImportExportBundle\Command\ExportCommand">
-            <argument key="$databaseHost">%env(DATABASE_HOST)%</argument>
-            <argument key="$databaseUser">%env(DATABASE_USER)%</argument>
-            <argument key="$databaseName">%env(DATABASE_NAME)%</argument>
-            <argument key="$databasePassword">%env(DATABASE_PASSWORD)%</argument>
-            <argument key="$exportDirectory">%kernel.project_dir%</argument>
-            <argument key="$uploadsDirectory">%env(MEDIA_PATH)%</argument>
+            <argument key="$exportService" type="service" id="sulu.service.export"/>
             <tag name="console.command"/>
         </service>
     </services>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -8,7 +8,7 @@
             <argument key="$databaseUser">%env(DATABASE_USER)%</argument>
             <argument key="$databaseName">%env(DATABASE_NAME)%</argument>
             <argument key="$databasePassword">%env(DATABASE_PASSWORD)%</argument>
-            <argument key="$importDirectory">%kernel.project_dir%</argument>
+            <argument key="$exportDirectory">%kernel.project_dir%</argument>
             <argument key="$uploadsDirectory">%env(MEDIA_PATH)%</argument>
             <argument key="$executeService" type="service" id="sulu.service.execute"/>
         </service>
@@ -17,7 +17,7 @@
             <argument key="$databaseUser">%env(DATABASE_USER)%</argument>
             <argument key="$databaseName">%env(DATABASE_NAME)%</argument>
             <argument key="$databasePassword">%env(DATABASE_PASSWORD)%</argument>
-            <argument key="$exportDirectory">%kernel.project_dir%</argument>
+            <argument key="$importDirectory">%kernel.project_dir%</argument>
             <argument key="$uploadsDirectory">%env(MEDIA_PATH)%</argument>
             <argument key="$executeService" type="service" id="sulu.service.execute"/>
         </service>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="sulu.service.export" class="TheCadien\Bundle\SuluImportExportBundle\Service\ExportService">
+            <argument key="$databaseHost">%env(DATABASE_HOST)%</argument>
+            <argument key="$databaseUser">%env(DATABASE_USER)%</argument>
+            <argument key="$databaseName">%env(DATABASE_NAME)%</argument>
+            <argument key="$databasePassword">%env(DATABASE_PASSWORD)%</argument>
+            <argument key="$importDirectory">%kernel.project_dir%</argument>
+            <argument key="$uploadsDirectory">%env(MEDIA_PATH)%</argument>
+            <argument key="$executeService" type="service" id="sulu.service.execute"/>
+        </service>
+        <service id="sulu.service.import" class="TheCadien\Bundle\SuluImportExportBundle\Service\ImportService">
+            <argument key="$databaseHost">%env(DATABASE_HOST)%</argument>
+            <argument key="$databaseUser">%env(DATABASE_USER)%</argument>
+            <argument key="$databaseName">%env(DATABASE_NAME)%</argument>
+            <argument key="$databasePassword">%env(DATABASE_PASSWORD)%</argument>
+            <argument key="$exportDirectory">%kernel.project_dir%</argument>
+            <argument key="$uploadsDirectory">%env(MEDIA_PATH)%</argument>
+            <argument key="$executeService" type="service" id="sulu.service.execute"/>
+        </service>
+
+        <service id="sulu.service.execute" class="TheCadien\Bundle\SuluImportExportBundle\Service\ExecuteService">
+            <argument type="service" id="kernel"/>
+        </service>
+    </services>
+</container>

--- a/Service/ExecuteService.php
+++ b/Service/ExecuteService.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of TheCadien/SuluImportExportBundle.
+ *
+ * (c) Oliver Kossin
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace TheCadien\Bundle\SuluImportExportBundle\Service;
+
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+class ExecuteService
+{
+    /**
+     * @var Application
+     */
+    private $application;
+
+    public function __construct(KernelInterface $kernel)
+    {
+        $this->application = new Application($kernel);
+    }
+
+    public function executeCommand($cmd, array $params, OutputInterface $output)
+    {
+        $command = $this->application->find($cmd);
+        $command->run(
+            new ArrayInput(
+                ['command' => $cmd] + $params
+            ),
+            $output
+        );
+    }
+}

--- a/Service/ExportInterface.php
+++ b/Service/ExportInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of TheCadien/SuluImportExportBundle.
+ *
+ * (c) Oliver Kossin
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace TheCadien\Bundle\SuluImportExportBundle\Service;
+
+interface ExportInterface
+{
+    public function exportPHPCR();
+
+    public function exportDatabase();
+
+    public function exportUploads();
+}

--- a/Service/ExportService.php
+++ b/Service/ExportService.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of TheCadien/SuluImportExportBundle.
+ *
+ * (c) Oliver Kossin
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace TheCadien\Bundle\SuluImportExportBundle\Service;
+
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\Process;
+use TheCadien\Bundle\SuluImportExportBundle\Helper\ImportExportDefaultMap;
+
+class ExportService implements ExportInterface
+{
+    private $databaseHost;
+    private $databaseUser;
+    private $databaseName;
+    private $databasePassword;
+    private $exportDirectory;
+    private $uploadsDirectory;
+    /**
+     * @var ExecuteService
+     */
+    private $executeService;
+
+    public function __construct(
+        string $databaseHost,
+        string $databaseName,
+        string $databaseUser,
+        string $databasePassword,
+        string $exportDirectory,
+        string $uploadsDirectory,
+        ExecuteService $executeService
+    ) {
+        parent::__construct();
+        $this->databaseHost = $databaseHost;
+        $this->databaseUser = $databaseUser;
+        $this->databaseName = $databaseName;
+        $this->databasePassword = $databasePassword;
+        $this->exportDirectory = $exportDirectory;
+        $this->executeService = $executeService;
+        $this->uploadsDirectory = ($uploadsDirectory) ?: ImportExportDefaultMap::SULU_DEFAULT_MEDIA_PATH;
+    }
+
+    public function exportPHPCR()
+    {
+        $this->executeService->executeCommand(
+            'doctrine:phpcr:workspace:export',
+            [
+                '-p' => '/cmf',
+                'filename' => $this->exportDirectory . \DIRECTORY_SEPARATOR . ImportExportDefaultMap::FILENAME_PHPCR,
+            ],
+            new NullOutput()
+        );
+    }
+
+    public function exportDatabase()
+    {
+        $command =
+            "mysqldump -h {$this->databaseHost} -u " . escapeshellarg($this->databaseUser) .
+            ($this->databasePassword ? ' -p' . escapeshellarg($this->databasePassword) : '') .
+            ' ' . escapeshellarg($this->databaseName) . ' > ' . $this->exportDirectory . \DIRECTORY_SEPARATOR . ImportExportDefaultMap::FILENAME_SQL;
+
+        $process = Process::fromShellCommandline($command);
+        $process->run();
+
+        if (!$process->isSuccessful()) {
+            throw new ProcessFailedException($process);
+        }
+    }
+
+    public function exportUploads()
+    {
+        // Directory path with new Symfony directory structure - i.e. var/uploads.
+        $process = Process::fromShellCommandline(
+            'tar cvf ' . $this->exportDirectory . \DIRECTORY_SEPARATOR . ImportExportDefaultMap::FILENAME_UPLOADS . " {$this->uploadsDirectory}"
+        );
+        $process->setTimeout(300);
+        $process->run();
+
+        if (!$process->isSuccessful()) {
+            throw new ProcessFailedException($process);
+        }
+    }
+}

--- a/Service/ExportService.php
+++ b/Service/ExportService.php
@@ -40,7 +40,6 @@ class ExportService implements ExportInterface
         string $uploadsDirectory,
         ExecuteService $executeService
     ) {
-        parent::__construct();
         $this->databaseHost = $databaseHost;
         $this->databaseUser = $databaseUser;
         $this->databaseName = $databaseName;

--- a/Service/ImportInterface.php
+++ b/Service/ImportInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of TheCadien/SuluImportExportBundle.
+ *
+ * (c) Oliver Kossin
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace TheCadien\Bundle\SuluImportExportBundle\Service;
+
+interface ImportInterface
+{
+    public function importPHPCR();
+
+    public function importDatabase();
+
+    public function importUploads();
+}

--- a/Service/ImportService.php
+++ b/Service/ImportService.php
@@ -44,7 +44,6 @@ class ImportService implements ImportInterface
         string $uploadsDirectory,
         ExecuteService $executeService
     ) {
-        parent::__construct();
         $this->databaseHost = $databaseHost;
         $this->databaseUser = $databaseUser;
         $this->databaseName = $databaseName;

--- a/Service/ImportService.php
+++ b/Service/ImportService.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of TheCadien/SuluImportExportBundle.
+ *
+ * (c) Oliver Kossin
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace TheCadien\Bundle\SuluImportExportBundle\Service;
+
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\Process;
+use TheCadien\Bundle\SuluImportExportBundle\Helper\ImportExportDefaultMap;
+
+class ImportService implements ImportInterface
+{
+    private $databaseHost;
+    private $databaseUser;
+    private $databaseName;
+    private $databasePassword;
+    private $importDirectory;
+    private $uploadsDirectory;
+
+    /**
+     * @var ExecuteService
+     */
+    private $executeService;
+
+    /**
+     * ImportCommand constructor.
+     */
+    public function __construct(
+        string $databaseHost,
+        string $databaseName,
+        string $databaseUser,
+        string $databasePassword,
+        string $importDirectory,
+        string $uploadsDirectory,
+        ExecuteService $executeService
+    ) {
+        parent::__construct();
+        $this->databaseHost = $databaseHost;
+        $this->databaseUser = $databaseUser;
+        $this->databaseName = $databaseName;
+        $this->databasePassword = $databasePassword;
+        $this->importDirectory = $importDirectory;
+        $this->executeService = $executeService;
+        $this->uploadsDirectory = ($uploadsDirectory) ?: ImportExportDefaultMap::SULU_DEFAULT_MEDIA_PATH;
+    }
+
+    public function importPHPCR()
+    {
+        $this->executeService->executeCommand(
+            'doctrine:phpcr:workspace:purge',
+            [
+                '--force' => true,
+            ],
+            new NullOutput()
+        );
+        $this->executeService->executeCommand(
+            'doctrine:phpcr:workspace:import',
+            [
+                'filename' => $this->importDirectory . \DIRECTORY_SEPARATOR . ImportExportDefaultMap::FILENAME_PHPCR,
+            ],
+            new NullOutput()
+        );
+    }
+
+    public function importDatabase()
+    {
+        $command =
+            "mysql -h {$this->databaseHost} -u " . escapeshellarg($this->databaseUser) .
+            ($this->databasePassword ? ' -p' . escapeshellarg($this->databasePassword) : '') .
+            ' ' . escapeshellarg($this->databaseName) . ' < ' . $this->importDirectory . \DIRECTORY_SEPARATOR . ImportExportDefaultMap::FILENAME_SQL;
+        $process = Process::fromShellCommandline($command);
+        $process->run();
+        if (!$process->isSuccessful()) {
+            throw new ProcessFailedException($process);
+        }
+    }
+
+    public function importUploads()
+    {
+        $filename = $this->importDirectory . \DIRECTORY_SEPARATOR . ImportExportDefaultMap::FILENAME_UPLOADS;
+        $path = $this->uploadsDirectory . \DIRECTORY_SEPARATOR;
+        $process = Process::fromShellCommandline("tar -xvf {$filename} {$path}");
+        $process->run();
+        if (!$process->isSuccessful()) {
+            throw new ProcessFailedException($process);
+        }
+    }
+}


### PR DESCRIPTION
That the individual export and import steps can also be used outside the bundle, these are handled in separate services and made available as an interface.