### PR TITLE
Allow symfony/framework-bundle 6.x in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "sulu/sulu": "^2.0.1",
     "symfony/config": "^4.3 || ^5.0 || ^6.0",
     "symfony/dependency-injection": "^4.3 || ^5.0 || ^6.0",
-    "symfony/framework-bundle": "^4.3 || ^5.0",
+    "symfony/framework-bundle": "^4.3 || ^5.0 || ^6.0",
     "symfony/http-foundation": "^4.3 || ^5.0 || ^6.0",
     "symfony/http-kernel": "^4.3 || ^5.0.7 || ^6.0"
   },


### PR DESCRIPTION
In the readme it is said that this bundle supports Symfony 6, but the version constraint for symfony/framework-bundle did not allow anything > 5.x.

I have fixed that and tested with symfony 6 and it works ;-)

If you like this PR I'd be happy if you labeled it with [`hacktoberfest-accepted`](https://hacktoberfest.com/participation/). Thanks in advance.