### PR TITLE
Reuse doctrine's connection params

### DIFF
--- a/DependencyInjection/Compiler/DbConnectionPass.php
+++ b/DependencyInjection/Compiler/DbConnectionPass.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of TheCadien/SuluImportExportBundle.
+ *
+ * (c) Oliver Kossin
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace TheCadien\Bundle\SuluImportExportBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * This compiler pass is responsible for fetching the connection params
+ * of the DBAL and passes them to our export and import service.
+ */
+class DbConnectionPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        $connectionName = $container->getParameter('sulu_import_export_bundle.dbal_connection');
+
+        if (!$connectionName) {
+            $connectionName = $container->getParameter('doctrine.default_connection');
+        }
+
+        $connections = $container->getParameter('doctrine.connections');
+
+        if (!isset($connections[$connectionName])) {
+            throw new \InvalidArgumentException(sprintf('There is no doctrine connection configured which is named "%s". Available names are "%s".', $connectionName, implode('", "', array_keys($connections))));
+        }
+
+        $connectionId = $connections[$connectionName];
+        $connectionParams = $container->getDefinition($connectionId)->getArgument(0);
+
+        $exportService = $container->getDefinition('sulu.service.export');
+        $exportService->setArgument('$databaseParams', $connectionParams);
+
+        $importService = $container->getDefinition('sulu.service.import');
+        $importService->setArgument('$databaseParams', $connectionParams);
+    }
+}

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -28,6 +28,14 @@ class Configuration implements ConfigurationInterface
     {
         $treeBuilder = new TreeBuilder('import_export_bundle');
 
+        $rootNode = $treeBuilder->getRootNode();
+        $rootNode
+            ->children()
+                ->scalarNode('dbal_connection')
+                    ->defaultNull()
+                ->end()
+            ->end();
+
         return $treeBuilder;
     }
 }

--- a/DependencyInjection/SuluImportExportExtension.php
+++ b/DependencyInjection/SuluImportExportExtension.php
@@ -33,6 +33,8 @@ class SuluImportExportExtension extends Extension
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
+        $container->setParameter('sulu_import_export_bundle.dbal_connection', $config['dbal_connection']);
+
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('command.xml');
         $loader->load('services.xml');

--- a/Helper/DbConnectionParamsNormalizer.php
+++ b/Helper/DbConnectionParamsNormalizer.php
@@ -57,7 +57,7 @@ class DbConnectionParamsNormalizer
             'host' => $urlParts['host'] ?? 'localhost',
             'user' => $urlParts['user'],
             'dbname' => substr($urlParts['path'], 1),
-            'password' => $urlParts['password'] ?? null,
+            'password' => $urlParts['pass'] ?? null,
         ];
     }
 }

--- a/Helper/DbConnectionParamsNormalizer.php
+++ b/Helper/DbConnectionParamsNormalizer.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of TheCadien/SuluImportExportBundle.
+ *
+ * (c) Oliver Kossin
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace TheCadien\Bundle\SuluImportExportBundle\Helper;
+
+class DbConnectionParamsNormalizer
+{
+    /**
+     * Normalizes the array with the connection params to a defined structure.
+     *
+     * @param array $connectionParams
+     *        The database connection params for the connection. Should be passed
+     *        as an associative array with the key 'url' or with the keys 'host',
+     *        'user', 'dbname' and 'password'.
+     *        If an URL is used, it should follow the format
+     *        'mysql://<user>:<password>@<host>/<dbname>'.
+     *
+     * @throws \InvalidArgumentException if the passed array does not contain the required fields
+     *
+     * @return array Returns an array with the keys 'host', 'user', 'dbname' and 'password'.
+     *         The latter may be null.
+     */
+    public static function normalize(array $connectionParams): array
+    {
+        if (empty($connectionParams['url'])) {
+            $diff = array_diff_key(['user', 'dbname'], $connectionParams);
+
+            if (\count($diff) > 0) {
+                throw new \InvalidArgumentException(sprintf('The following keys are missing from the $connectionParams: ', implode(', ', $diff)));
+            }
+
+            return [
+                'host' => $connectionParams['host'] ?? 'localhost',
+                'user' => $connectionParams['user'],
+                'dbname' => $connectionParams['dbname'],
+                'password' => $connectionParams['password'] ?? null,
+            ];
+        }
+
+        $urlParts = parse_url($connectionParams['url']);
+
+        if (false === $urlParts) {
+            throw new \InvalidArgumentException('The connection URL is not a valid URL that follows the format "<schema>://<user>:<password>@<host>/<dbname>');
+        }
+
+        return [
+            'host' => $urlParts['host'] ?? 'localhost',
+            'user' => $urlParts['user'],
+            'dbname' => substr($urlParts['path'], 1),
+            'password' => $urlParts['password'] ?? null,
+        ];
+    }
+}

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -4,19 +4,13 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
         <service id="sulu.service.export" class="TheCadien\Bundle\SuluImportExportBundle\Service\ExportService">
-            <argument key="$databaseHost">%env(DATABASE_HOST)%</argument>
-            <argument key="$databaseUser">%env(DATABASE_USER)%</argument>
-            <argument key="$databaseName">%env(DATABASE_NAME)%</argument>
-            <argument key="$databasePassword">%env(DATABASE_PASSWORD)%</argument>
+            <argument key="$databaseParams"><!-- dynamically set per DbConnectionPass --></argument>
             <argument key="$exportDirectory">%kernel.project_dir%/%env(EXPORT_DIR)%</argument>
             <argument key="$uploadsDirectory">%env(MEDIA_PATH)%</argument>
             <argument key="$executeService" type="service" id="sulu.service.execute"/>
         </service>
         <service id="sulu.service.import" class="TheCadien\Bundle\SuluImportExportBundle\Service\ImportService">
-            <argument key="$databaseHost">%env(DATABASE_HOST)%</argument>
-            <argument key="$databaseUser">%env(DATABASE_USER)%</argument>
-            <argument key="$databaseName">%env(DATABASE_NAME)%</argument>
-            <argument key="$databasePassword">%env(DATABASE_PASSWORD)%</argument>
+            <argument key="$databaseParams"><!-- dynamically set per DbConnectionPass --></argument>
             <argument key="$importDirectory">%kernel.project_dir%/%env(IMPORT_DIR)%</argument>
             <argument key="$uploadsDirectory">%env(MEDIA_PATH)%</argument>
             <argument key="$executeService" type="service" id="sulu.service.execute"/>

--- a/Service/ExportService.php
+++ b/Service/ExportService.php
@@ -16,6 +16,7 @@ namespace TheCadien\Bundle\SuluImportExportBundle\Service;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
+use TheCadien\Bundle\SuluImportExportBundle\Helper\DbConnectionParamsNormalizer;
 use TheCadien\Bundle\SuluImportExportBundle\Helper\ImportExportDefaultMap;
 
 class ExportService implements ExportInterface
@@ -31,19 +32,27 @@ class ExportService implements ExportInterface
      */
     private $executeService;
 
+    /**
+     * @param array $databaseParams
+     *        The database connection params for the connection. Should be passed
+     *        as an associative array with the key 'url' or with the keys 'host',
+     *        'user', 'dbname' and 'password'.
+     *        If an URL is used, it should follow the format
+     *        'mysql://<user>:<password>@<host>/<dbname>'.
+     */
     public function __construct(
-        string $databaseHost,
-        string $databaseName,
-        string $databaseUser,
-        string $databasePassword,
+        array $databaseParams,
         string $exportDirectory,
         string $uploadsDirectory,
         ExecuteService $executeService
     ) {
-        $this->databaseHost = $databaseHost;
-        $this->databaseUser = $databaseUser;
-        $this->databaseName = $databaseName;
-        $this->databasePassword = $databasePassword;
+        $databaseParams = DbConnectionParamsNormalizer::normalize($databaseParams);
+
+        $this->databaseHost = $databaseParams['host'];
+        $this->databaseUser = $databaseParams['user'];
+        $this->databaseName = $databaseParams['dbname'];
+        $this->databasePassword = $databaseParams['password'];
+
         $this->exportDirectory = $exportDirectory;
         $this->executeService = $executeService;
         $this->uploadsDirectory = ($uploadsDirectory) ?: ImportExportDefaultMap::SULU_DEFAULT_MEDIA_PATH;

--- a/Service/ImportService.php
+++ b/Service/ImportService.php
@@ -16,6 +16,7 @@ namespace TheCadien\Bundle\SuluImportExportBundle\Service;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
+use TheCadien\Bundle\SuluImportExportBundle\Helper\DbConnectionParamsNormalizer;
 use TheCadien\Bundle\SuluImportExportBundle\Helper\ImportExportDefaultMap;
 
 class ImportService implements ImportInterface
@@ -34,20 +35,27 @@ class ImportService implements ImportInterface
 
     /**
      * ImportCommand constructor.
+     *
+     * @param array $databaseParams
+     *        The database connection params for the connection. Should be passed
+     *        as an associative array with the key 'url' or with the keys 'host',
+     *        'user', 'dbname' and 'password'.
+     *        If an URL is used, it should follow the format
+     *        'mysql://<user>:<password>@<host>/<dbname>'.
      */
     public function __construct(
-        string $databaseHost,
-        string $databaseName,
-        string $databaseUser,
-        string $databasePassword,
+        array $databaseParams,
         string $importDirectory,
         string $uploadsDirectory,
         ExecuteService $executeService
     ) {
-        $this->databaseHost = $databaseHost;
-        $this->databaseUser = $databaseUser;
-        $this->databaseName = $databaseName;
-        $this->databasePassword = $databasePassword;
+        $databaseParams = DbConnectionParamsNormalizer::normalize($databaseParams);
+
+        $this->databaseHost = $databaseParams['host'];
+        $this->databaseUser = $databaseParams['user'];
+        $this->databaseName = $databaseParams['dbname'];
+        $this->databasePassword = $databaseParams['password'];
+
         $this->importDirectory = $importDirectory;
         $this->executeService = $executeService;
         $this->uploadsDirectory = ($uploadsDirectory) ?: ImportExportDefaultMap::SULU_DEFAULT_MEDIA_PATH;

--- a/SuluImportExportBundle.php
+++ b/SuluImportExportBundle.php
@@ -13,8 +13,17 @@ declare(strict_types=1);
 
 namespace TheCadien\Bundle\SuluImportExportBundle;
 
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
+use TheCadien\Bundle\SuluImportExportBundle\DependencyInjection\Compiler\DbConnectionPass;
 
 class SuluImportExportBundle extends Bundle
 {
+    /**
+     * {@inheritDoc}
+     */
+    public function build(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new DbConnectionPass());
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
   ],
   "require": {
     "php": "^7.3|^8.0",
+    "doctrine/doctrine-bundle": ">=1.0",
     "sulu/sulu": "^2.0.1",
     "symfony/config": "^4.3 || ^5.0 || ^6.0",
     "symfony/dependency-injection": "^4.3 || ^5.0 || ^6.0",

--- a/readme.md
+++ b/readme.md
@@ -29,13 +29,19 @@ composer require thecadien/sulu-import-export-bundle
 
 ### Configure the bundle 
 
-Configure arguments in your `.env` with your Database Config like the following way.
+If the doctrine database connection used by Sulu is not the 'default' DBAL
+connection you have to specify the connection name in the bundle's configuration.
+
+```yaml
+# config/packages/sulu_import_export.yaml
+
+sulu_import_export:
+    dbal_connection: default
+```
+
+Configure the import and export paths in your `.env` in the following way.
 
  ```dotenv
-DATABASE_HOST='host'
-DATABASE_USER='user'
-DATABASE_PASSWORD='password'
-DATABASE_NAME='db-name'
 MEDIA_PATH='var/uploads/media'
 
 IMPORT_DIR='var/import/'


### PR DESCRIPTION
Currently the user of this bundle has to config the database connection params additionally to the doctrine connection if the `DATABASE_URL` is used instead of the specific params.

This change adds an auto detection of the connection params used for doctrine. In the case the sulu database differs from the default connection the correct one can be specified in the bundle's config. The readme is updated, too, to reflect this change.

If you like this PR I'd be happy if you labeled it with [`hacktoberfest-accepted`](https://hacktoberfest.com/participation/). Thanks in advance.