### PR TITLE
Commands have to return an integer value

### DIFF
--- a/Command/ExportCommand.php
+++ b/Command/ExportCommand.php
@@ -76,5 +76,7 @@ class ExportCommand extends Command
         $this->output->writeln(
             \PHP_EOL . '<info>Successfully exported contents.</info>'
         );
+
+        return 0;
     }
 }

--- a/Command/ImportCommand.php
+++ b/Command/ImportCommand.php
@@ -88,5 +88,7 @@ class ImportCommand extends Command
         $this->output->writeln(
             \PHP_EOL . "<info>Successfully imported contents. You're good to go!</info>"
         );
+
+        return 0;
     }
 }


### PR DESCRIPTION
Since symfony 4.4 it is [deprecated](https://github.com/symfony/console/blob/4.4/Command/Command.php#L258) to not return an integer value from a command's `execute` method. Since symfony 5.0 not returning an integer raises a [TypeError](https://github.com/symfony/console/blob/5.0/Command/Command.php#L258).

This change adds a `return 0;` at the end of the two commands.

If you like this PR I'd be happy if you labeled it with [`hacktoberfest-accepted`](https://hacktoberfest.com/participation/). Thanks in advance.