### PR TITLE
Added return types to phpdoc comments to fix deprecations

### DIFF
--- a/Command/ExportCommand.php
+++ b/Command/ExportCommand.php
@@ -46,6 +46,9 @@ class ExportCommand extends Command
         $this->exportService = $exportService;
     }
 
+    /**
+     * @return void
+     */
     protected function configure()
     {
         $this
@@ -53,6 +56,9 @@ class ExportCommand extends Command
             ->setDescription('Exports all Sulu contents (PHPCR, database, uploads) to the web directory.');
     }
 
+    /**
+     * @return int
+     */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $this->input = $input;

--- a/Command/ImportCommand.php
+++ b/Command/ImportCommand.php
@@ -49,6 +49,9 @@ class ImportCommand extends Command
         $this->importService = $importService;
     }
 
+    /**
+     * @return void
+     */
     protected function configure()
     {
         $this
@@ -62,6 +65,9 @@ class ImportCommand extends Command
             );
     }
 
+    /**
+     * @return int
+     */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $this->input = $input;

--- a/DependencyInjection/Compiler/DbConnectionPass.php
+++ b/DependencyInjection/Compiler/DbConnectionPass.php
@@ -24,6 +24,8 @@ class DbConnectionPass implements CompilerPassInterface
 {
     /**
      * {@inheritDoc}
+     *
+     * @return void
      */
     public function process(ContainerBuilder $container)
     {

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -23,6 +23,8 @@ class Configuration implements ConfigurationInterface
 {
     /**
      * {@inheritdoc}
+     *
+     * @return TreeBuilder
      */
     public function getConfigTreeBuilder()
     {

--- a/DependencyInjection/SuluImportExportExtension.php
+++ b/DependencyInjection/SuluImportExportExtension.php
@@ -27,6 +27,8 @@ class SuluImportExportExtension extends Extension
 {
     /**
      * {@inheritdoc}
+     *
+     * @return void
      */
     public function load(array $configs, ContainerBuilder $container)
     {


### PR DESCRIPTION
This PR fixes the following deprecation messages by adding a "soft" return type to the phpdoc comments (to keep BC):


>  Method "Symfony\Component\DependencyInjection\Extension\ExtensionInterface::load()" might add "void" as a native return type declaration in the future. Do the same in implementation "TheCadien\Bundle\SuluImportExportBundle\DependencyInjection\SuluImportExportExtension" now to avoid errors or add an explicit @return annotation to suppress this message.
>
>  Method "Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface::process()" might add "void" as a native return type declaration in the future. Do the same in implementation "TheCadien\Bundle\SuluImportExportBundle\DependencyInjection\Compiler\DbConnectionPass" now to avoid errors or add an explicit @return annotation to suppress this message.
>
>  Method "Symfony\Component\Config\Definition\ConfigurationInterface::getConfigTreeBuilder()" might add "TreeBuilder" as a native return type declaration in the future. Do the same in implementation "TheCadien\Bundle\SuluImportExportBundle\DependencyInjection\Configuration" now to avoid errors or add an explicit @return annotation to suppress this message.
>
>  Method "Symfony\Component\Console\Command\Command::configure()" might add "void" as a native return type declaration in the future. Do the same in child class "TheCadien\Bundle\SuluImportExportBundle\Command\ImportCommand" now to avoid errors or add an explicit @return annotation to suppress this message.
>
>  Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "TheCadien\Bundle\SuluImportExportBundle\Command\ImportCommand" now to avoid errors or add an explicit @return annotation to suppress this message.
>
>  Method "Symfony\Component\Console\Command\Command::configure()" might add "void" as a native return type declaration in the future. Do the same in child class "TheCadien\Bundle\SuluImportExportBundle\Command\ExportCommand" now to avoid errors or add an explicit @return annotation to suppress this message.
>
>  Method "Symfony\Component\Console\Command\Command::execute()" might add "int" as a native return type declaration in the future. Do the same in child class "TheCadien\Bundle\SuluImportExportBundle\Command\ExportCommand" now to avoid errors or add an explicit @return annotation to suppress this message.